### PR TITLE
FIX Path to point to  the right file name

### DIFF
--- a/src/stream/example12/example12.js
+++ b/src/stream/example12/example12.js
@@ -20,7 +20,7 @@ const destinationFile = fs.createWriteStream(`${__dirname}/src/stream/example12/
 
 // Launch callback when Destination Array finish.
 destinationFile.on('finish', () => {
-  fs.readFile(`${__dirname}/src/stream/example13/destination-text.txt`, (err, data) => {
+  fs.readFile(`${__dirname}/src/stream/example12/destination-text.txt`, (err, data) => {
     if (err) console.error(err);
     console.log('destinationFile -> ', data.toString());
   });


### PR DESCRIPTION
`fs.readFile` points to `example13`  instead of `example12`. Fixed the typo.